### PR TITLE
Empêcher les ragots vide

### DIFF
--- a/app.js
+++ b/app.js
@@ -36,6 +36,7 @@ app.get('/', function(req, res) {
 });
 
 app.post('/ragots', function(req, res) {
+  if(!req.body.message.replace(/\s/g,"")) return res.redirect('/');
   redisClient.incr('ragots:count', function(err, i) {
     async.parallel([
       function(cb) { redisClient.set('ragots:'+i, req.body.message, cb); },
@@ -44,6 +45,7 @@ app.post('/ragots', function(req, res) {
       if(!err) res.redirect('/');
     });
   });
+  return null;
 });
 
 app.listen(process.env.PORT || 3000);

--- a/views/index.jade
+++ b/views/index.jade
@@ -6,7 +6,7 @@ html(lang="fr")
     != css('styles')
   body
     form#new-ragot(action="/ragots", method="POST")
-      textarea(type="text", name="message", placeholder="Il parait que...", autocomplete="off", autofocus)
+      textarea(type="text", name="message", placeholder="Il parait que...", autocomplete="off", autofocus, required)
       input(type="submit", value="Ragoter")
     ul#ragots
       each ragot in ragots


### PR DESCRIPTION
Juste pour signaler qu'on peut poster des ragots vides :)

aussi, y a eu un export de trop de l'ancien site ragots, tous les ragots sont en double 
